### PR TITLE
Fix default values and get_group method

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: octo
 name: azuread
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.1.0
+version: 0.2.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
Change default values to create security groups by default.
Use filter in get_group to avoid multiple call of the API endpoint because
of the pagination.